### PR TITLE
Add possibility to stop motor.turn()

### DIFF
--- a/examples/tutorial/stop_turning_motor.py
+++ b/examples/tutorial/stop_turning_motor.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+import nxt.locator
+import nxt.motor
+
+import time
+import threading
+
+with nxt.locator.find() as b:
+    # Get the motor connected to the port A.
+    mymotor: nxt.motor.BaseMotor = b.get_motor(nxt.motor.Port.A)
+
+    stop_motor = False  # controls wether the motor should stop turning
+
+    # create thread that turns the motor
+    t = threading.Thread(target=mymotor.turn, kwargs={
+                         'power': 50, 'tacho_units': 360*4, 'brake': True, 'stop_turn': lambda: stop_motor})
+    t.start()
+
+    # stop motor after 1sec (motor would turn approximately 3sec)
+    time.sleep(1)
+    stop_motor = True
+
+    t.join()
+
+    # release motor after 1sec since brake=True
+    time.sleep(1)
+    mymotor.idle()

--- a/nxt/motor.py
+++ b/nxt/motor.py
@@ -257,14 +257,16 @@ class BaseMotor:
 
         try:
             while not stop_turn():
-                current_time = time.time()
+                time.sleep(0.1)
 
                 if current_time - last_time < sleep_time:
+                    current_time = time.time()
                     continue
                 else:
                     if not blocked:  # if still blocked, don't reset the counter
                         last_tacho = tacho
                         last_time = current_time
+                    current_time = time.time()
 
                 tacho = self.get_tacho()
                 blocked = self._is_blocked(tacho, last_tacho, direction)

--- a/nxt/motor.py
+++ b/nxt/motor.py
@@ -197,7 +197,7 @@ def get_tacho_and_state(values):
 class BaseMotor:
     """Base class for motors"""
 
-    def turn(self, power, tacho_units, brake=True, timeout=1, emulate=True):
+    def turn(self, power, tacho_units, brake=True, timeout=1, emulate=True, stop_turn=lambda: False):
         """Use this to turn a motor.
 
         :param int power: Value between -127 and 128 (an absolute value greater than 64
@@ -212,9 +212,11 @@ class BaseMotor:
            If ``True``, a run() function equivalent is used. Warning: motors remember
            their positions and not using emulate may lead to strange behavior,
            especially with synced motors
+        :param lambda: bool stop_turn: If stop_turn returns ``True`` the motor stops turning. 
+           Depending on ``brake`` it stops by holding or not holding the motor.
 
-        The motor will not stop until it turns the desired distance. Accuracy is much
-        better over a USB connection than with bluetooth...
+        The motor will not stop until it turns the desired distance or stop_turn is set to True. 
+        Accuracy is much better over a USB connection than with bluetooth...
         """
 
         tacho_limit = tacho_units
@@ -246,20 +248,25 @@ class BaseMotor:
 
         direction = 1 if power > 0 else -1
         logger.debug("tachocount: %s", tacho)
+
         current_time = time.time()
+        last_time = time.time()
         tacho_target = tacho.get_target(tacho_limit, direction)
-
         blocked = False
-        try:
-            while True:
-                time.sleep(self._eta(tacho, tacho_target, power) / 2)
+        sleep_time = self._eta(tacho, tacho_target, power) / 2
 
-                if not blocked:  # if still blocked, don't reset the counter
-                    last_tacho = tacho
-                    last_time = current_time
+        try:
+            while not stop_turn():
+                current_time = time.time()
+
+                if current_time - last_time < sleep_time:
+                    continue
+                else:
+                    if not blocked:  # if still blocked, don't reset the counter
+                        last_tacho = tacho
+                        last_time = current_time
 
                 tacho = self.get_tacho()
-                current_time = time.time()
                 blocked = self._is_blocked(tacho, last_tacho, direction)
                 if blocked:
                     logger.debug("not advancing: %s %s", last_tacho, tacho)
@@ -272,10 +279,13 @@ class BaseMotor:
                             raise BlockedException("Blocked!")
                 else:
                     logger.debug("advancing: %s %s", last_tacho, tacho)
+
                 if tacho.is_near(tacho_target, threshold) or tacho.is_greater(
                     tacho_target, direction
                 ):
                     break
+
+                sleep_time = self._eta(tacho, tacho_target, power) / 2
         finally:
             if brake:
                 self.brake()


### PR DESCRIPTION
This feature adds the possibility of stopping motor.turn() before it completes.

By passing a lambda function (returning True or False) as the `stop_turn` argument, you can stop the `motor.turn()` at any point by making the lambda function return `False`.

Usually, you would want to have a thread that turns the motor. This allows you to run other operations like reading sensor data simultaneously in the main thread and then stopping the `motor.turn()` operation early.

An example usage can be found [here](https://github.com/marvinknoll/nxt-python/blob/6f83ad4ef0314da888cb582a30ce1c916409bf47/examples/tutorial/stop_turning_motor.py).

The respective mailing list discussion can be found [here](https://lists.sr.ht/~ni/nxt-python/%3CijwmxumH19YBvSyvQoUrILZoHrH6Qsg7EeUH_64Wron3ICxTWK4J8KQf4AsH5u2R56aXBe-3w-imvJ7UYcWq0IeOl0zGGXgxwLIu90MItT8%3D%40protonmail.com%3E).