### PR TITLE
bluetooth.py: handle discover_devices returning bytes (instead of str)

### DIFF
--- a/nxt/backend/bluetooth.py
+++ b/nxt/backend/bluetooth.py
@@ -122,6 +122,8 @@ class Backend:
             else:
                 devhost, devname = dev, None
             if (host is None or devhost == host) and (name is None or devname == name):
+                if type(devhost) is bytes:
+                    devhost = devhost.decode('utf8')
                 sock = BluetoothSock(self._bluetooth, devhost)
                 try:
                     brick = sock.connect()

--- a/tests/test_backend_bluetooth.py
+++ b/tests/test_backend_bluetooth.py
@@ -85,7 +85,7 @@ def test_bluetooth(mbluetooth, mbluetooth_import, msock):
     backend = nxt.backend.bluetooth.get_backend()
     # Find brick.
     mbluetooth.discover_devices.return_value = [
-        "00:01:02:03:04:05",
+        b"00:01:02:03:04:05",
     ]
     bricks = list(backend.find(blah="blah"))
     assert len(bricks) == 1


### PR DESCRIPTION
discover_devices returns bytes instead of str (might be unique to macOS or the latest version of pybluez/lightblue?)